### PR TITLE
Add support for packages containing a single archive file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cocoapods-azure-universal-packages (0.0.1)
+    cocoapods-azure-universal-packages (0.0.2)
       addressable (~> 2.6)
       cocoapods (~> 1.0)
       cocoapods-downloader (~> 1.0)

--- a/lib/cocoapods-azure-universal-packages/azure_universal_package_downloader.rb
+++ b/lib/cocoapods-azure-universal-packages/azure_universal_package_downloader.rb
@@ -28,6 +28,29 @@ module Pod
 
         if !aup_uri_components.nil? && Downloader.azure_base_urls.include?("#{aup_uri_components['scheme']}://#{aup_uri_components['host']}")
           download_azure_universal_package!(aup_uri_components)
+
+          # Extract the file if it's the only one in the package
+          package_files = target_path.glob('*')
+          if package_files.count == 1 && package_files.first.file?
+            file = package_files.first
+            file_type = begin
+              case file.to_s
+              when /\.zip$/
+                :zip
+              when /\.(tgz|tar\.gz)$/
+                :tgz
+              when /\.tar$/
+                :tar
+              when /\.(tbz|tar\.bz2)$/
+                :tbz
+              when /\.(txz|tar\.xz)$/
+                :txz
+              when /\.dmg$/
+                :dmg
+              end
+            end
+            extract_with_type(file, file_type) unless file_type.nil?
+          end
         else
           aliased_download!
         end

--- a/lib/cocoapods-azure-universal-packages/gem_version.rb
+++ b/lib/cocoapods-azure-universal-packages/gem_version.rb
@@ -1,3 +1,3 @@
 module CocoapodsAzureUniversalPackages
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
If the package contains a single file and the file is an archive, it will be extracted automatically.