### PR TITLE
Replace "base url" with "organization url"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cocoapods-azure-universal-packages (0.0.2)
+    cocoapods-azure-universal-packages (0.1.0)
       addressable (~> 2.6)
       cocoapods (~> 1.0)
       cocoapods-downloader (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -30,22 +30,21 @@ _Note:_ The plugin will install the Azure CLI [DevOps extension](https://github.
 Add to your Podfile
 ```Ruby
 plugin 'cocoapods-azure-universal-packages', {
-    :base_url => '{{BASE_URL}}'
+    :organization => '{{ORGANIZATION_URL}}'
 }
 ```
-replacing `{{BASE_URL}}` with the base URL of your Azure Artifacts feed (for example, `https://pkgs.dev.azure.com/`).
+replacing `{{ORGANIZATION_URL}}` with the base URL of your Azure Artifacts feed (for example: `https://pkgs.dev.azure.com/myorg`).
 
 Then, in your podspec set the pod's source to
 ```Ruby
 # For project scoped feeds:
-spec.source = { :http => '{{BASE_URL}}/{{ORGANIZATION}}/{{PROJECT}}/_apis/packaging/feeds/{{FEED}}/upack/packages/{{PACKAGE}}/versions/{{VERSION}}' }
+spec.source = { :http => '{{ORGANIZATION_URL}}/{{PROJECT}}/_apis/packaging/feeds/{{FEED}}/upack/packages/{{PACKAGE}}/versions/{{VERSION}}' }
 
 # For organization scoped feeds:
-spec.source = { :http => '{{BASE_URL}}/{{ORGANIZATION}}/_apis/packaging/feeds/{{FEED}}/upack/packages/{{PACKAGE}}/versions/{{VERSION}}' }
+spec.source = { :http => '{{ORGANIZATION_URL}}/_apis/packaging/feeds/{{FEED}}/upack/packages/{{PACKAGE}}/versions/{{VERSION}}' }
 ```
 where:
-- `{{BASE_URL}}` is the base URL you chose above
-- `{{ORGANIZATION}}` is the name of your feed's organization
+- `{{ORGANIZATION_URL}}` is the URL of your feed's organization
 - `{{PROJECT}}` is the name of your feed's project (you must specify this only if your feed is a project scoped feed)
 - `{{PACKAGE}}` is the name of your universal package
 - `{{VERSION}}` is the version of your universal package
@@ -54,8 +53,8 @@ where:
 
 | Parameter | Description |
 | --------- | ----------- |
-| `base_url` | The base URL of the Azure Artifacts feed. Required unless `base_urls` is specified. |
-| `base_urls` | An array of base URLs of possible Azure Artifacts feeds. Required unless `base_url` is specified. |
+| `organization` | The URL of the Azure Artifacts feed's orgnization. Required unless `organizations` is specified. |
+| `organizations` | An array of URLs of possible Azure Artifacts feeds' organizations. Required unless `organization` is specified. |
 | `update_cli_extension` | Whether to update the Azure CLI DevOps extensions automatically. Default to `false`. |
 
 ## Run tests for this plugin

--- a/lib/cocoapods-azure-universal-packages/azure_universal_package_downloader.rb
+++ b/lib/cocoapods-azure-universal-packages/azure_universal_package_downloader.rb
@@ -60,6 +60,7 @@ module Pod
               extract_with_type(file, file_type) unless file_type.nil?
             end
           else
+            Pod::UserInterface.warn("#{url} looks like a Azure artifact feed but it's malformed")
             aliased_download!
           end
         end

--- a/lib/cocoapods-azure-universal-packages/azure_universal_package_downloader.rb
+++ b/lib/cocoapods-azure-universal-packages/azure_universal_package_downloader.rb
@@ -5,10 +5,10 @@ require 'cocoapods-downloader'
 module Pod
   module Downloader
 
-    @azure_base_urls = []
+    @azure_organizations = []
 
     class << self
-      attr_accessor :azure_base_urls
+      attr_accessor :azure_organizations
     end
 
     class Http
@@ -20,39 +20,48 @@ module Pod
       executable :az
 
       def download!
-        aup_uri_template = Addressable::Template.new(
-          '{scheme}://{host}/{organization}{/project}/_apis/packaging/feeds/{feed}/upack/packages/{package}/versions/{version}'
-        )
-        uri = Addressable::URI.parse(url)
-        aup_uri_components = aup_uri_template.extract(uri)
+        # Check if the url matches any known Azure organization
+        organization = Downloader.azure_organizations.find { |org| url.to_s.start_with?(org) }
 
-        if !aup_uri_components.nil? && Downloader.azure_base_urls.include?("#{aup_uri_components['scheme']}://#{aup_uri_components['host']}")
-          download_azure_universal_package!(aup_uri_components)
-
-          # Extract the file if it's the only one in the package
-          package_files = target_path.glob('*')
-          if package_files.count == 1 && package_files.first.file?
-            file = package_files.first
-            file_type = begin
-              case file.to_s
-              when /\.zip$/
-                :zip
-              when /\.(tgz|tar\.gz)$/
-                :tgz
-              when /\.tar$/
-                :tar
-              when /\.(tbz|tar\.bz2)$/
-                :tbz
-              when /\.(txz|tar\.xz)$/
-                :txz
-              when /\.dmg$/
-                :dmg
-              end
-            end
-            extract_with_type(file, file_type) unless file_type.nil?
-          end
-        else
+        if organization.nil?
           aliased_download!
+        else
+          # Parse the url
+          organization.delete_suffix!('/')
+          aup_uri_template = Addressable::Template.new(
+            "#{organization}{/project}/_apis/packaging/feeds/{feed}/upack/packages/{package}/versions/{version}"
+          )
+          uri = Addressable::URI.parse(url)
+          aup_uri_components = aup_uri_template.extract(uri)
+
+          if !aup_uri_components.nil?
+            download_azure_universal_package!(aup_uri_components.merge({ 'organization' => organization }))
+  
+            # Extract the file if it's the only one in the package
+            package_files = target_path.glob('*')
+            if package_files.count == 1 && package_files.first.file?
+              file = package_files.first
+              file_type = begin
+                case file.to_s
+                when /\.zip$/
+                  :zip
+                when /\.(tgz|tar\.gz)$/
+                  :tgz
+                when /\.tar$/
+                  :tar
+                when /\.(tbz|tar\.bz2)$/
+                  :tbz
+                when /\.(txz|tar\.xz)$/
+                  :txz
+                when /\.dmg$/
+                  :dmg
+                end
+              end
+              extract_with_type(file, file_type) unless file_type.nil?
+            end
+          else
+            aliased_download!
+          end
         end
       end
 
@@ -62,7 +71,7 @@ module Pod
             'artifacts',
             'universal',
             'download',
-            '--organization', "#{params['scheme']}://#{params['host']}/#{params['organization']}/",
+            '--organization', params['organization'],
             '--feed', params['feed'],
             '--name', params['package'],
             '--version', params['version'],

--- a/lib/cocoapods-azure-universal-packages/gem_version.rb
+++ b/lib/cocoapods-azure-universal-packages/gem_version.rb
@@ -1,3 +1,3 @@
 module CocoapodsAzureUniversalPackages
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end

--- a/lib/cocoapods-azure-universal-packages/pre_install.rb
+++ b/lib/cocoapods-azure-universal-packages/pre_install.rb
@@ -18,11 +18,11 @@ module CocoapodsAzureUniversalPackages
       end
 
       # Now we can configure the downloader to use the Azure CLI for downloading pods from the given hosts
-      azure_base_urls = options[:base_url] || options[:base_urls]
-      raise Pod::Informative, 'You must configure at least one Azure base url' unless azure_base_urls
+      azure_organizations = options[:organization] || options[:organizations]
+      raise Pod::Informative, 'You must configure at least one Azure organization' unless azure_organizations
 
-      Pod::Downloader.azure_base_urls = ([] << azure_base_urls).flatten.map { |url| url.delete_suffix('/') }
-      raise Pod::Informative, 'You must configure at least one Azure base url' if Pod::Downloader.azure_base_urls.empty?
+      Pod::Downloader.azure_organizations = ([] << azure_organizations).flatten.map { |url| url.delete_suffix('/') }
+      raise Pod::Informative, 'You must configure at least one Azure organization' if Pod::Downloader.azure_organizations.empty?
     end
 
   end

--- a/spec/cocoapods-azure-universal-packages/azure_universal_package_downloader_spec.rb
+++ b/spec/cocoapods-azure-universal-packages/azure_universal_package_downloader_spec.rb
@@ -25,11 +25,8 @@ describe Pod::Downloader::Http do
         "https://dev.azure.com/test_org",
         "https://test_org.azure.com"
       ].each do |org|
-        before(:each) do
-          Pod::Downloader.azure_organizations = [org]
-        end
-
         it "can download universal packages from organization feeds with an organization url like #{org}" do
+          Pod::Downloader.azure_organizations = [org]
           downloader = Pod::Downloader::Http.new("/tmp", "#{org}/_apis/packaging/feeds/org_feed/upack/packages/test_package/versions/1.2.3", {})
           parameters = [
             'artifacts',
@@ -49,6 +46,7 @@ describe Pod::Downloader::Http do
         end
   
         it "can download universal packages from project feeds with an organization url like #{org}" do
+          Pod::Downloader.azure_organizations = [org]
           downloader = Pod::Downloader::Http.new("/tmp", "#{org}/test_project/_apis/packaging/feeds/project_feed/upack/packages/test_package/versions/1.2.3", {})
           parameters = [
             'artifacts',

--- a/spec/cocoapods-azure-universal-packages/azure_universal_package_downloader_spec.rb
+++ b/spec/cocoapods-azure-universal-packages/azure_universal_package_downloader_spec.rb
@@ -5,10 +5,10 @@ describe Pod::Downloader::Http do
   describe "#download!" do
 
     before(:each) do
-      Pod::Downloader.azure_base_urls = ["https://pkgs.dev.azure.com"]
+      Pod::Downloader.azure_organizations = ["https://pkgs.dev.azure.com/test_org"]
     end
 
-    context 'when not downloading a pod from one of the configured base urls' do
+    context 'when not downloading a pod from one of the configured Azure organizations' do
       it 'calls #aliased_download!' do
         downloader = Pod::Downloader::Http.new("/tmp", "https://www.microsoft.com", {})
 
@@ -19,45 +19,55 @@ describe Pod::Downloader::Http do
       end
     end
 
-    context 'when downloading a pod from one of the configured base urls' do
-      it 'can download universal packages from organization feeds' do
-        downloader = Pod::Downloader::Http.new("/tmp", "https://pkgs.dev.azure.com/test_org/_apis/packaging/feeds/org_feed/upack/packages/test_package/versions/1.2.3", {})
-        parameters = [
-          'artifacts',
-          'universal',
-          'download',
-          '--organization', 'https://pkgs.dev.azure.com/test_org/',
-          '--feed', 'org_feed',
-          '--name', 'test_package',
-          '--version', '1.2.3',
-          '--path', '/tmp'
-        ]
+    context 'when downloading a pod from one of the configured Azure organizations' do
 
-        downloader.target_path.stubs(:mkpath)
-        downloader.target_path.stubs(:glob).returns([])
-        downloader.expects(:execute_command).with('az', parameters, anything)
-        downloader.download
-      end
+      %w[
+        "https://dev.azure.com/test_org",
+        "https://test_org.azure.com"
+      ].each do |org|
+        before(:each) do
+          Pod::Downloader.azure_organizations = [org]
+        end
 
-      it 'can download universal packages from project feeds' do
-        downloader = Pod::Downloader::Http.new("/tmp", "https://pkgs.dev.azure.com/test_org/test_project/_apis/packaging/feeds/project_feed/upack/packages/test_package/versions/1.2.3", {})
-        parameters = [
-          'artifacts',
-          'universal',
-          'download',
-          '--organization', 'https://pkgs.dev.azure.com/test_org/',
-          '--feed', 'project_feed',
-          '--name', 'test_package',
-          '--version', '1.2.3',
-          '--path', '/tmp',
-          '--project', 'test_project',
-          '--scope', 'project'
-        ]
-
-        downloader.target_path.stubs(:mkpath)
-        downloader.target_path.stubs(:glob).returns([])
-        downloader.expects(:execute_command).with('az', parameters, anything)
-        downloader.download
+        it "can download universal packages from organization feeds with an organization url like #{org}" do
+          downloader = Pod::Downloader::Http.new("/tmp", "#{org}/_apis/packaging/feeds/org_feed/upack/packages/test_package/versions/1.2.3", {})
+          parameters = [
+            'artifacts',
+            'universal',
+            'download',
+            '--organization', org,
+            '--feed', 'org_feed',
+            '--name', 'test_package',
+            '--version', '1.2.3',
+            '--path', '/tmp'
+          ]
+  
+          downloader.target_path.stubs(:mkpath)
+          downloader.target_path.stubs(:glob).returns([])
+          downloader.expects(:execute_command).with('az', parameters, anything)
+          downloader.download
+        end
+  
+        it "can download universal packages from project feeds with an organization url like #{org}" do
+          downloader = Pod::Downloader::Http.new("/tmp", "#{org}/test_project/_apis/packaging/feeds/project_feed/upack/packages/test_package/versions/1.2.3", {})
+          parameters = [
+            'artifacts',
+            'universal',
+            'download',
+            '--organization', org,
+            '--feed', 'project_feed',
+            '--name', 'test_package',
+            '--version', '1.2.3',
+            '--path', '/tmp',
+            '--project', 'test_project',
+            '--scope', 'project'
+          ]
+  
+          downloader.target_path.stubs(:mkpath)
+          downloader.target_path.stubs(:glob).returns([])
+          downloader.expects(:execute_command).with('az', parameters, anything)
+          downloader.download
+        end
       end
     end
 

--- a/spec/cocoapods-azure-universal-packages/azure_universal_package_downloader_spec.rb
+++ b/spec/cocoapods-azure-universal-packages/azure_universal_package_downloader_spec.rb
@@ -21,7 +21,7 @@ describe Pod::Downloader::Http do
 
     context 'when downloading a pod from one of the configured Azure organizations' do
 
-      %w[
+      [
         "https://dev.azure.com/test_org",
         "https://test_org.azure.com"
       ].each do |org|

--- a/spec/cocoapods-azure-universal-packages/pre_install_spec.rb
+++ b/spec/cocoapods-azure-universal-packages/pre_install_spec.rb
@@ -5,11 +5,11 @@ describe CocoapodsAzureUniversalPackages do
   describe ".pre_install" do
 
     before(:each) do
-      Pod::Downloader.azure_base_urls = []
+      Pod::Downloader.azure_organizations = []
     end
 
     context 'when Azure CLI is not installed' do
-      let(:options) { {:base_url => "https://dev.azure.com/"} }
+      let(:options) { {:organization => "https://dev.azure.com/test_org"} }
 
       it 'raises an exception' do
         Pod::Executable.expects(:which).with('az').returns(nil)
@@ -18,7 +18,7 @@ describe CocoapodsAzureUniversalPackages do
     end
 
     context 'when Azure CLI is installed' do
-      let(:base_options) { {:base_url => "https://dev.azure.com/"} }
+      let(:base_options) { {:organization => "https://dev.azure.com/test_org"} }
 
       before(:each) do
         Pod::Executable.stubs(:which).with('az').returns('az')
@@ -44,35 +44,35 @@ describe CocoapodsAzureUniversalPackages do
         end
       end
 
-      %w[base_url base_urls].each do |url_option|
+      %w[organization organizations].each do |url_option|
         context "with a string specified in '#{url_option}'" do
           it 'adds the url to the downloader' do
-            Pod::Downloader.expects(:azure_base_urls=).with(includes("https://dev.azure.com"))
-            Pod::Downloader.stubs(:azure_base_urls).returns(["https://dev.azure.com"])
+            Pod::Downloader.expects(:azure_organizations=).with(includes("https://dev.azure.com"))
+            Pod::Downloader.stubs(:azure_organizations).returns(["https://dev.azure.com"])
             CocoapodsAzureUniversalPackages.pre_install({url_option.to_sym => "https://dev.azure.com/"})
           end
         end
 
         context "with an array specified in '#{url_option}'" do
           it 'adds the url to the downloader' do
-            Pod::Downloader.expects(:azure_base_urls=).with(all_of(includes("https://dev.azure.com"), includes("https://pkgs.dev.azure.com")))
-            Pod::Downloader.stubs(:azure_base_urls).returns(["https://dev.azure.com", "https://pkgs.dev.azure.com"])
+            Pod::Downloader.expects(:azure_organizations=).with(all_of(includes("https://dev.azure.com"), includes("https://pkgs.dev.azure.com")))
+            Pod::Downloader.stubs(:azure_organizations).returns(["https://dev.azure.com", "https://pkgs.dev.azure.com"])
             CocoapodsAzureUniversalPackages.pre_install({url_option.to_sym => ["https://dev.azure.com/", "https://pkgs.dev.azure.com/"]})
           end
         end
 
         context "with an empty array specified in '#{url_option}'" do
           it 'raises an exception' do
-            Pod::Downloader.expects(:azure_base_urls=).with(equals([]))
-            Pod::Downloader.stubs(:azure_base_urls).returns([])
+            Pod::Downloader.expects(:azure_organizations=).with(equals([]))
+            Pod::Downloader.stubs(:azure_organizations).returns([])
             expect { CocoapodsAzureUniversalPackages.pre_install({url_option.to_sym => []}) }.to raise_error(Pod::Informative, '[!] You must configure at least one Azure base url'.red)
           end
         end
       end
 
-      context "without a base url argument" do
+      context "without an organization argument" do
         it 'raises an exception' do
-          Pod::Downloader.expects(:azure_base_urls=).never
+          Pod::Downloader.expects(:azure_organizations=).never
           expect { CocoapodsAzureUniversalPackages.pre_install({}) }.to raise_error(Pod::Informative, '[!] You must configure at least one Azure base url'.red)
         end
       end

--- a/spec/cocoapods-azure-universal-packages/pre_install_spec.rb
+++ b/spec/cocoapods-azure-universal-packages/pre_install_spec.rb
@@ -65,7 +65,7 @@ describe CocoapodsAzureUniversalPackages do
           it 'raises an exception' do
             Pod::Downloader.expects(:azure_organizations=).with(equals([]))
             Pod::Downloader.stubs(:azure_organizations).returns([])
-            expect { CocoapodsAzureUniversalPackages.pre_install({url_option.to_sym => []}) }.to raise_error(Pod::Informative, '[!] You must configure at least one Azure base url'.red)
+            expect { CocoapodsAzureUniversalPackages.pre_install({url_option.to_sym => []}) }.to raise_error(Pod::Informative, '[!] You must configure at least one Azure organization'.red)
           end
         end
       end
@@ -73,7 +73,7 @@ describe CocoapodsAzureUniversalPackages do
       context "without an organization argument" do
         it 'raises an exception' do
           Pod::Downloader.expects(:azure_organizations=).never
-          expect { CocoapodsAzureUniversalPackages.pre_install({}) }.to raise_error(Pod::Informative, '[!] You must configure at least one Azure base url'.red)
+          expect { CocoapodsAzureUniversalPackages.pre_install({}) }.to raise_error(Pod::Informative, '[!] You must configure at least one Azure organization'.red)
         end
       end
     end


### PR DESCRIPTION
Adds support for organizations that have a url like `https://myorg.visualstudio.com` instead of `https://dev.azure.com/myorg`.

This includes braking changes because the `base_url` option has been renamed to `organization` and now the organization name must be included in the url.