### PR TITLE
Fix: Flatten extracted archives analogous to cocoapods-downloader

### DIFF
--- a/lib/cocoapods-azure-universal-packages/azure_universal_package_downloader.rb
+++ b/lib/cocoapods-azure-universal-packages/azure_universal_package_downloader.rb
@@ -57,6 +57,8 @@ module Pod
                   :dmg
                 end
               end
+              self.options[:type] = file_type
+              @filename = File.basename(file)
               extract_with_type(file, file_type) unless file_type.nil?
             end
           else


### PR DESCRIPTION
When a universal package contains a single tar archive, this archive will automatically be extracted. This is great, however for tar archives (among others) it's common that they contain a single directory with the same name as the tar file (without the `.tar` or `.tar.gz` extension). The `extract_with_type` function defined in the `cocoapods-downloader` module usually takes care of extracting the children of such folders, in order to create the correct structure for installing the CocoaPod. However, for this to work, we have to set some properties/options before calling `extract_with_type`:

- `filename`: This property is used by the `extract_with_type` function to distinguish the archive from the extracted directory (see https://github.com/CocoaPods/cocoapods-downloader/blob/master/lib/cocoapods-downloader/remote_file.rb#L109).
- `type`: Whether an extracted directory should be flattened is decided according to the type of its corresponding archive. If we don't set the type explicitly, `cocoapods-downloader` will determine the type automatically from the `url` property, which in case of universal packages, does not contain the `.tar` or any other archive type extension. We therefore need to set the type explicitly for the flattening to work (see https://github.com/CocoaPods/cocoapods-downloader/blob/master/lib/cocoapods-downloader/remote_file.rb#L52 and https://github.com/CocoaPods/cocoapods-downloader/blob/master/lib/cocoapods-downloader/remote_file.rb#L30)